### PR TITLE
feat(bond): vite helper + Funcs plumbing for runtime asset resolution

### DIFF
--- a/bond/bond.go
+++ b/bond/bond.go
@@ -27,6 +27,12 @@ type Config struct {
 	ContainerID    string // Default: "app"
 	EncryptHistory bool   // Use pkg/crypto for history state encryption
 	SSR            SSRConfig
+
+	// Funcs registers template helpers available inside RootTemplate.
+	// Typical use: bond/vite emits {{ vite "resources/js/app.tsx" }}
+	// which expands to <link>/<script> tags appropriate for the
+	// current dev/prod mode. nil means no custom helpers.
+	Funcs template.FuncMap
 }
 
 // SSRConfig configures server-side rendering. When Enabled is false
@@ -119,7 +125,7 @@ func New(config Config) (*Bond, error) {
 	}
 
 	// Parse the template
-	tmpl, err := parseTemplate(config.RootTemplate)
+	tmpl, err := parseTemplateWithFuncs(config.RootTemplate, config.Funcs)
 	if err != nil {
 		return nil, err
 	}

--- a/bond/template.go
+++ b/bond/template.go
@@ -5,8 +5,15 @@ import (
 	"strings"
 )
 
-// parseTemplate parses and validates the root HTML template
+// parseTemplate parses and validates the root HTML template.
 func parseTemplate(templateStr string) (*template.Template, error) {
+	return parseTemplateWithFuncs(templateStr, nil)
+}
+
+// parseTemplateWithFuncs is parseTemplate plus a FuncMap registered
+// before parsing so the template can call helpers like
+// {{ vite "..." }}. funcs may be nil.
+func parseTemplateWithFuncs(templateStr string, funcs template.FuncMap) (*template.Template, error) {
 	if templateStr == "" {
 		return nil, ErrTemplateRequired
 	}
@@ -16,7 +23,11 @@ func parseTemplate(templateStr string) (*template.Template, error) {
 		return nil, ErrInvalidTemplate
 	}
 
-	return template.New("root").Parse(templateStr)
+	tmpl := template.New("root")
+	if funcs != nil {
+		tmpl = tmpl.Funcs(funcs)
+	}
+	return tmpl.Parse(templateStr)
 }
 
 // TemplateData holds data passed to the root HTML template

--- a/bond/template_test.go
+++ b/bond/template_test.go
@@ -3,8 +3,47 @@ package bond
 import (
 	"bytes"
 	"html/template"
+	"strings"
 	"testing"
 )
+
+func TestParseTemplateWithFuncs_RegistersFunc(t *testing.T) {
+	tmpl, err := parseTemplateWithFuncs(
+		`<html><body>{{ shout "hi" }} {{ .inertia }}</body></html>`,
+		template.FuncMap{
+			"shout": func(s string) string { return s + "!" },
+		},
+	)
+	if err != nil {
+		t.Fatalf("parseTemplateWithFuncs failed: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, map[string]any{"inertia": ""}); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "hi!") {
+		t.Errorf("expected output to contain 'hi!', got: %s", got)
+	}
+}
+
+func TestNew_PropagatesFuncsIntoTemplate(t *testing.T) {
+	b, err := New(Config{
+		RootTemplate: `<html><body>{{ shout "hi" }} {{ .inertia }}</body></html>`,
+		Funcs: template.FuncMap{
+			"shout": func(s string) string { return s + "!" },
+		},
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := b.template.Execute(&buf, map[string]any{"inertia": ""}); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "hi!") {
+		t.Errorf("expected output to contain 'hi!', got: %s", got)
+	}
+}
 
 func TestParseTemplate_Valid(t *testing.T) {
 	tmpl, err := parseTemplate(`<!DOCTYPE html>

--- a/bond/vite/vite.go
+++ b/bond/vite/vite.go
@@ -1,0 +1,442 @@
+// Package vite emits Vite asset tags from a Go template.
+//
+// It mirrors Laravel's Illuminate\Foundation\Vite helper: a single Tags
+// call decides between the dev server (when public/hot exists) and the
+// production manifest (public/build/.vite/manifest.json), and returns
+// the appropriate <link>/<script> markup.
+//
+// Typical wiring through bond.Config.Funcs:
+//
+//	helper := vite.New()
+//	cfg.Funcs = template.FuncMap{
+//	    "vite": helper.Tags,
+//	}
+//
+// Then in the root template:
+//
+//	{{ vite "resources/js/app.tsx" }}
+//
+// Dev mode is signalled by the presence of a "hot" file written by
+// `vel serve` (or any equivalent process) containing the dev-server
+// origin (e.g. "http://localhost:5173"). When the file is absent the
+// helper reads the Vite manifest, looks up each entrypoint, and emits
+// stylesheet links plus the entry script tag, with modulepreload links
+// for each statically imported chunk.
+package vite
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Default file/directory names. Match Laravel + the @inertiajs/vite plugin.
+const (
+	DefaultPublicPath       = "public"
+	DefaultBuildDirectory   = "build"
+	DefaultHotFile          = "hot"
+	DefaultManifestFilename = "manifest.json"
+	DefaultManifestSubdir   = ".vite"
+)
+
+// ErrManifestNotFound is returned when the Vite manifest is missing in
+// production mode. The caller is almost always the root template, so the
+// message includes the resolved path to make misconfigured deployments
+// (typical cause: forgot to run `bun run build`) easy to diagnose.
+var ErrManifestNotFound = errors.New("vite: manifest not found")
+
+// ErrEntrypointNotInManifest indicates the requested entrypoint key is
+// missing from the manifest. The build either did not include the file
+// as an entry, or the template requested a path with a typo.
+var ErrEntrypointNotInManifest = errors.New("vite: entrypoint not in manifest")
+
+// Helper resolves Vite assets to HTML tags. It is safe for concurrent
+// use; the manifest is cached in memory and re-read when the file's
+// modification time changes (zero overhead in production where the
+// manifest is immutable, automatic refresh after `bun run build`).
+type Helper struct {
+	publicPath       string
+	buildDirectory   string
+	hotFile          string
+	manifestFilename string
+	manifestSubdir   string
+
+	mu         sync.RWMutex
+	cached     manifest
+	cachedPath string
+	cachedMod  int64
+}
+
+// Option configures a Helper. Use the With* constructors.
+type Option func(*Helper)
+
+// WithPublicPath sets the directory containing built assets and the hot
+// file (default "public").
+func WithPublicPath(p string) Option { return func(h *Helper) { h.publicPath = p } }
+
+// WithBuildDirectory sets the subdirectory of public/ where Vite writes
+// its build output (default "build"). Must match `base` in vite.config.
+func WithBuildDirectory(p string) Option { return func(h *Helper) { h.buildDirectory = p } }
+
+// WithHotFile sets the hot-file name relative to public/ (default
+// "hot"). The file's content is the dev-server origin URL.
+func WithHotFile(name string) Option { return func(h *Helper) { h.hotFile = name } }
+
+// WithManifestFilename sets the manifest filename inside the manifest
+// subdirectory (default "manifest.json").
+func WithManifestFilename(name string) Option {
+	return func(h *Helper) { h.manifestFilename = name }
+}
+
+// WithManifestSubdir sets the subdirectory of the build directory where
+// Vite writes the manifest (default ".vite", which matches Vite 5+).
+// Pass "" to read the manifest directly from the build directory.
+func WithManifestSubdir(p string) Option { return func(h *Helper) { h.manifestSubdir = p } }
+
+// New constructs a Helper with sensible defaults overridden by opts.
+func New(opts ...Option) *Helper {
+	h := &Helper{
+		publicPath:       DefaultPublicPath,
+		buildDirectory:   DefaultBuildDirectory,
+		hotFile:          DefaultHotFile,
+		manifestFilename: DefaultManifestFilename,
+		manifestSubdir:   DefaultManifestSubdir,
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// IsRunningHot reports whether the dev server is active. The signal is
+// the presence of the hot file — written by `vel serve` when starting
+// Vite, removed on shutdown.
+func (h *Helper) IsRunningHot() bool {
+	_, err := os.Stat(h.hotFilePath())
+	return err == nil
+}
+
+// Tags returns the HTML to inject for the given entrypoints. In dev
+// mode it emits the @vite/client script plus one script per entrypoint
+// pointed at the dev server. In production mode it walks the manifest
+// to emit stylesheet links, modulepreload links for static imports,
+// and the entry script.
+//
+// Returned errors render as an HTML comment containing the message —
+// templates cannot signal errors directly, and a comment is far less
+// catastrophic in a deployed page than a panic or a 500. The error is
+// also returned so callers that want strict behavior can wrap Tags.
+func (h *Helper) Tags(entrypoints ...string) (template.HTML, error) {
+	if h.IsRunningHot() {
+		hot, err := h.hotURL()
+		if err != nil {
+			return errComment(err), err
+		}
+		var b strings.Builder
+		b.WriteString(scriptTag(joinURL(hot, "@vite/client")))
+		for _, ep := range entrypoints {
+			b.WriteString(scriptTag(joinURL(hot, ep)))
+		}
+		return template.HTML(b.String()), nil
+	}
+
+	m, err := h.manifest()
+	if err != nil {
+		return errComment(err), err
+	}
+
+	var (
+		preloads     []string
+		stylesheets  []string
+		scripts      []string
+		seenPreloads = map[string]struct{}{}
+		seenCSS      = map[string]struct{}{}
+	)
+
+	addPreload := func(file string) {
+		if _, ok := seenPreloads[file]; ok {
+			return
+		}
+		seenPreloads[file] = struct{}{}
+		preloads = append(preloads, modulePreloadTag(h.assetURL(file)))
+	}
+	addCSS := func(file string) {
+		if _, ok := seenCSS[file]; ok {
+			return
+		}
+		seenCSS[file] = struct{}{}
+		stylesheets = append(stylesheets, stylesheetTag(h.assetURL(file)))
+	}
+
+	for _, ep := range entrypoints {
+		chunk, ok := m[ep]
+		if !ok {
+			err := fmt.Errorf("%w: %s", ErrEntrypointNotInManifest, ep)
+			return errComment(err), err
+		}
+
+		// Preload chunks the entry imports — gives the browser a head
+		// start while it parses the entry script. Matches Laravel's
+		// behavior in Vite::__invoke.
+		for _, imp := range chunk.Imports {
+			if dep, ok := m[imp]; ok {
+				addPreload(dep.File)
+				for _, css := range dep.CSS {
+					addCSS(css)
+				}
+			}
+		}
+		for _, css := range chunk.CSS {
+			addCSS(css)
+		}
+		scripts = append(scripts, scriptTag(h.assetURL(chunk.File)))
+	}
+
+	out := strings.Join(preloads, "") + strings.Join(stylesheets, "") + strings.Join(scripts, "")
+	return template.HTML(out), nil
+}
+
+// ReactRefreshTag returns the React Fast Refresh preamble script when
+// running against the Vite dev server, or an empty string in production.
+// The preamble must execute before @vite/client loads, so the typical
+// template usage is:
+//
+//	{{ viteReactRefresh }}
+//	{{ vite "resources/js/app.tsx" }}
+//
+// Apps that don't use @vitejs/plugin-react can skip this helper —
+// manifest mode never emits the preamble, so the prod path is unchanged.
+func (h *Helper) ReactRefreshTag() (template.HTML, error) {
+	if !h.IsRunningHot() {
+		return "", nil
+	}
+	hot, err := h.hotURL()
+	if err != nil {
+		return errComment(err), err
+	}
+	// The script body is what @vitejs/plugin-react injects into the
+	// entry HTML in dev mode. We render it inline here because the
+	// app's HTML is rendered by the Go template engine, not by Vite's
+	// transformIndexHtml — so the auto-injection never happens.
+	const preamble = `<script type="module">
+import RefreshRuntime from "%s/@react-refresh"
+RefreshRuntime.injectIntoGlobalHook(window)
+window.$RefreshReg$ = () => {}
+window.$RefreshSig$ = () => (type) => type
+window.__vite_plugin_react_preamble_installed__ = true
+</script>`
+	return template.HTML(fmt.Sprintf(preamble, template.HTMLEscapeString(hot))), nil
+}
+
+// Asset returns the public URL for an asset path. In dev mode it is
+// served by the Vite dev server; in production it is rooted at the
+// build directory under the public path.
+func (h *Helper) Asset(file string) (string, error) {
+	if h.IsRunningHot() {
+		hot, err := h.hotURL()
+		if err != nil {
+			return "", err
+		}
+		return joinURL(hot, file), nil
+	}
+	m, err := h.manifest()
+	if err != nil {
+		return "", err
+	}
+	chunk, ok := m[file]
+	if !ok {
+		return "", fmt.Errorf("%w: %s", ErrEntrypointNotInManifest, file)
+	}
+	return h.assetURL(chunk.File), nil
+}
+
+// hotFilePath returns the absolute filesystem path to the hot file.
+func (h *Helper) hotFilePath() string {
+	return filepath.Join(h.publicPath, h.hotFile)
+}
+
+// hotURL reads the dev-server origin from the hot file. The file's
+// trailing whitespace is trimmed — Vite writes a newline. The URL is
+// validated to start with http:// or https:// so a corrupt hot file
+// cannot inject arbitrary content into the script tags Tags() emits.
+func (h *Helper) hotURL() (string, error) {
+	b, err := os.ReadFile(h.hotFilePath())
+	if err != nil {
+		return "", fmt.Errorf("vite: read hot file: %w", err)
+	}
+	url := strings.TrimRight(string(b), " \r\n\t")
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return "", errInvalidHotURL
+	}
+	// Reject embedded whitespace or control bytes — a vite plugin
+	// writes a single-line URL; anything else is suspicious.
+	for _, r := range url {
+		if r < 0x20 || r == ' ' || r == '"' || r == '<' || r == '>' {
+			return "", errInvalidHotURL
+		}
+	}
+	return url, nil
+}
+
+// errInvalidHotURL is returned when public/hot does not contain a
+// well-formed http(s) URL. The most likely cause is a corrupt or
+// hand-written hot file; no scenario short of filesystem tampering
+// should produce one.
+var errInvalidHotURL = errors.New("vite: hot file does not contain a valid http(s) URL")
+
+// assetURL returns the absolute URL path for a built asset path
+// relative to the build directory (e.g. "assets/app-XXX.js" →
+// "/build/assets/app-XXX.js").
+func (h *Helper) assetURL(file string) string {
+	return "/" + path.Join(h.buildDirectory, file)
+}
+
+// manifest returns the parsed manifest, refreshing the cache if the
+// file's mtime has changed. The cache is keyed by absolute path so a
+// Helper reconfigured at runtime (e.g. in tests) does not return stale
+// data from a different path.
+func (h *Helper) manifest() (manifest, error) {
+	manifestPath := h.manifestPath()
+
+	st, err := os.Stat(manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrManifestNotFound, manifestPath)
+		}
+		return nil, fmt.Errorf("vite: stat manifest: %w", err)
+	}
+
+	mod := st.ModTime().UnixNano()
+
+	h.mu.RLock()
+	if h.cached != nil && h.cachedPath == manifestPath && h.cachedMod == mod {
+		m := h.cached
+		h.mu.RUnlock()
+		return m, nil
+	}
+	h.mu.RUnlock()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	// Re-check under write lock to avoid double-load when many
+	// goroutines miss the cache simultaneously.
+	if h.cached != nil && h.cachedPath == manifestPath && h.cachedMod == mod {
+		return h.cached, nil
+	}
+
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("vite: read manifest: %w", err)
+	}
+	parsed := manifest{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("vite: parse manifest: %w", err)
+	}
+
+	h.cached = parsed
+	h.cachedPath = manifestPath
+	h.cachedMod = mod
+	return parsed, nil
+}
+
+// manifestPath returns the absolute path to the manifest file.
+func (h *Helper) manifestPath() string {
+	parts := []string{h.publicPath, h.buildDirectory}
+	if h.manifestSubdir != "" {
+		parts = append(parts, h.manifestSubdir)
+	}
+	parts = append(parts, h.manifestFilename)
+	return filepath.Join(parts...)
+}
+
+// manifest is the parsed shape of Vite's manifest.json. We only model
+// the fields Tags walks; unknown fields are ignored.
+type manifest map[string]chunk
+
+// chunk is one entry in the Vite manifest. Field names match the JSON
+// keys Vite emits (file, src, css, imports, isEntry).
+type chunk struct {
+	File    string   `json:"file"`
+	Src     string   `json:"src,omitempty"`
+	CSS     []string `json:"css,omitempty"`
+	Imports []string `json:"imports,omitempty"`
+	IsEntry bool     `json:"isEntry,omitempty"`
+}
+
+func scriptTag(src string) string {
+	return `<script type="module" src="` + template.HTMLEscapeString(src) + `"></script>`
+}
+
+func stylesheetTag(href string) string {
+	return `<link rel="stylesheet" href="` + template.HTMLEscapeString(href) + `">`
+}
+
+func modulePreloadTag(href string) string {
+	return `<link rel="modulepreload" href="` + template.HTMLEscapeString(href) + `">`
+}
+
+// errComment emits a minimal HTML comment for a helper error. The
+// message is kept short and stripped of "-->" so a stray sequence in an
+// error chain cannot prematurely close the comment. Full filesystem
+// paths and stack traces are intentionally omitted — they belong in the
+// server log, not in HTML returned to a browser.
+func errComment(err error) template.HTML {
+	msg := err.Error()
+	// Trim chain noise: the leading sentinel name is enough for the
+	// page comment; the wrapping fmt.Errorf adds the path/entrypoint
+	// which we do not want to leak.
+	switch {
+	case errors.Is(err, ErrManifestNotFound):
+		msg = "manifest not found"
+	case errors.Is(err, ErrEntrypointNotInManifest):
+		msg = "entrypoint not in manifest"
+	}
+	msg = strings.ReplaceAll(msg, "-->", "--&gt;")
+	return template.HTML("<!-- vite: " + template.HTMLEscapeString(msg) + " -->")
+}
+
+// joinURL concatenates a base URL and a relative path with exactly one
+// slash between them. Both inputs may carry trailing/leading slashes.
+func joinURL(base, rel string) string {
+	base = strings.TrimRight(base, "/")
+	rel = strings.TrimLeft(rel, "/")
+	return base + "/" + rel
+}
+
+// WriteHotFile writes the dev-server origin to the hot file so the
+// helper switches into dev mode. Intended for `vel serve` to call when
+// it starts the Vite dev process.
+func WriteHotFile(publicPath, hotName, devURL string) error {
+	if hotName == "" {
+		hotName = DefaultHotFile
+	}
+	if publicPath == "" {
+		publicPath = DefaultPublicPath
+	}
+	if err := os.MkdirAll(publicPath, 0o755); err != nil {
+		return fmt.Errorf("vite: mkdir public: %w", err)
+	}
+	return os.WriteFile(filepath.Join(publicPath, hotName), []byte(devURL+"\n"), 0o644)
+}
+
+// RemoveHotFile removes the hot file, switching the helper back to
+// manifest mode. Safe to call when the file is absent.
+func RemoveHotFile(publicPath, hotName string) error {
+	if hotName == "" {
+		hotName = DefaultHotFile
+	}
+	if publicPath == "" {
+		publicPath = DefaultPublicPath
+	}
+	err := os.Remove(filepath.Join(publicPath, hotName))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/bond/vite/vite_test.go
+++ b/bond/vite/vite_test.go
@@ -1,0 +1,364 @@
+package vite
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeManifest creates a minimal but realistic Vite 5 manifest at
+// public/build/.vite/manifest.json beneath dir.
+func writeManifest(t *testing.T, dir string, body string) {
+	t.Helper()
+	mdir := filepath.Join(dir, "public", "build", ".vite")
+	if err := os.MkdirAll(mdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mdir, "manifest.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newHelperIn(t *testing.T, dir string) *Helper {
+	t.Helper()
+	return New(WithPublicPath(filepath.Join(dir, "public")))
+}
+
+func TestTags_HotMode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "public"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteHotFile(filepath.Join(dir, "public"), "", "http://localhost:5173"); err != nil {
+		t.Fatal(err)
+	}
+	h := newHelperIn(t, dir)
+
+	got, err := h.Tags("resources/js/app.tsx")
+	if err != nil {
+		t.Fatalf("Tags returned error: %v", err)
+	}
+	s := string(got)
+	for _, want := range []string{
+		`http://localhost:5173/@vite/client`,
+		`http://localhost:5173/resources/js/app.tsx`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("hot output missing %q\nfull: %s", want, s)
+		}
+	}
+	// In hot mode the manifest is irrelevant — none of the prod
+	// scaffolding should leak through.
+	for _, unwanted := range []string{`/build/`, `modulepreload`} {
+		if strings.Contains(s, unwanted) {
+			t.Errorf("hot output should not contain %q\nfull: %s", unwanted, s)
+		}
+	}
+}
+
+func TestTags_ProdMode_EmitsCSSAndScript(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{
+	  "resources/js/app.tsx": {
+	    "file": "assets/app-ABC.js",
+	    "src": "resources/js/app.tsx",
+	    "isEntry": true,
+	    "css": ["assets/app-XYZ.css"]
+	  }
+	}`)
+	h := newHelperIn(t, dir)
+
+	got, err := h.Tags("resources/js/app.tsx")
+	if err != nil {
+		t.Fatalf("Tags returned error: %v", err)
+	}
+	s := string(got)
+
+	wantStyle := `<link rel="stylesheet" href="/build/assets/app-XYZ.css">`
+	wantScript := `<script type="module" src="/build/assets/app-ABC.js"></script>`
+	if !strings.Contains(s, wantStyle) {
+		t.Errorf("prod output missing stylesheet tag\nwant substring: %s\nfull: %s", wantStyle, s)
+	}
+	if !strings.Contains(s, wantScript) {
+		t.Errorf("prod output missing script tag\nwant substring: %s\nfull: %s", wantScript, s)
+	}
+	// The stylesheet must come before the script — browsers should
+	// have CSS in flight before the JS executes.
+	if strings.Index(s, wantStyle) > strings.Index(s, wantScript) {
+		t.Errorf("stylesheet must precede script\nfull: %s", s)
+	}
+}
+
+func TestTags_ProdMode_PreloadsImports(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{
+	  "_chunk-A.js": {"file": "assets/chunk-A-1.js"},
+	  "_chunk-B.js": {"file": "assets/chunk-B-2.js", "css": ["assets/chunk-B.css"]},
+	  "resources/js/app.tsx": {
+	    "file": "assets/app-ABC.js",
+	    "src": "resources/js/app.tsx",
+	    "isEntry": true,
+	    "imports": ["_chunk-A.js", "_chunk-B.js"]
+	  }
+	}`)
+	h := newHelperIn(t, dir)
+
+	got, err := h.Tags("resources/js/app.tsx")
+	if err != nil {
+		t.Fatalf("Tags returned error: %v", err)
+	}
+	s := string(got)
+
+	for _, want := range []string{
+		`<link rel="modulepreload" href="/build/assets/chunk-A-1.js">`,
+		`<link rel="modulepreload" href="/build/assets/chunk-B-2.js">`,
+		`<link rel="stylesheet" href="/build/assets/chunk-B.css">`,
+		`<script type="module" src="/build/assets/app-ABC.js"></script>`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing tag %q\nfull: %s", want, s)
+		}
+	}
+}
+
+func TestTags_ProdMode_MissingManifestReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "public"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := newHelperIn(t, dir)
+
+	got, err := h.Tags("resources/js/app.tsx")
+	if err == nil {
+		t.Fatal("expected error for missing manifest")
+	}
+	if !errors.Is(err, ErrManifestNotFound) {
+		t.Errorf("error chain missing ErrManifestNotFound: %v", err)
+	}
+	if !strings.Contains(string(got), "<!-- vite:") {
+		t.Errorf("expected error comment in output, got: %s", got)
+	}
+}
+
+func TestTags_ProdMode_UnknownEntrypointReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{
+	  "resources/js/app.tsx": {"file": "assets/app.js", "isEntry": true}
+	}`)
+	h := newHelperIn(t, dir)
+
+	_, err := h.Tags("resources/js/missing.tsx")
+	if !errors.Is(err, ErrEntrypointNotInManifest) {
+		t.Fatalf("want ErrEntrypointNotInManifest, got %v", err)
+	}
+}
+
+func TestManifest_RefreshOnMtimeChange(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{
+	  "resources/js/app.tsx": {"file": "assets/v1.js", "isEntry": true}
+	}`)
+	h := newHelperIn(t, dir)
+
+	got, err := h.Tags("resources/js/app.tsx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "/build/assets/v1.js") {
+		t.Fatalf("first read missing v1.js: %s", got)
+	}
+
+	// Bump mtime forward so the cache invalidates regardless of how
+	// fast this test runs.
+	mpath := filepath.Join(dir, "public", "build", ".vite", "manifest.json")
+	future := mustFutureMtime(t, mpath)
+	if err := os.WriteFile(mpath, []byte(`{
+	  "resources/js/app.tsx": {"file": "assets/v2.js", "isEntry": true}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(mpath, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = h.Tags("resources/js/app.tsx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "/build/assets/v2.js") {
+		t.Fatalf("second read missing v2.js: %s", got)
+	}
+}
+
+func TestAsset(t *testing.T) {
+	dir := t.TempDir()
+
+	// Hot mode: dev URL passthrough.
+	if err := os.MkdirAll(filepath.Join(dir, "public"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteHotFile(filepath.Join(dir, "public"), "", "http://localhost:5173"); err != nil {
+		t.Fatal(err)
+	}
+	h := newHelperIn(t, dir)
+	got, err := h.Asset("resources/js/app.tsx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "http://localhost:5173/resources/js/app.tsx" {
+		t.Errorf("hot Asset = %q", got)
+	}
+
+	// Prod mode: manifest lookup.
+	if err := RemoveHotFile(filepath.Join(dir, "public"), ""); err != nil {
+		t.Fatal(err)
+	}
+	writeManifest(t, dir, `{
+	  "resources/js/app.tsx": {"file": "assets/app-ABC.js", "isEntry": true}
+	}`)
+	got, err = h.Asset("resources/js/app.tsx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/build/assets/app-ABC.js" {
+		t.Errorf("prod Asset = %q", got)
+	}
+}
+
+func TestHotURL_RejectsMalformedFile(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"non-http scheme", "javascript:alert(1)"},
+		{"no scheme", "localhost:5173"},
+		{"embedded space", "http://localhost:5173 evil"},
+		{"embedded angle", "http://x<script>"},
+		{"control char", "http://x\x01y"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			pub := filepath.Join(dir, "public")
+			if err := os.MkdirAll(pub, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(pub, "hot"), []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			h := newHelperIn(t, dir)
+			_, err := h.Tags("resources/js/app.tsx")
+			if err == nil {
+				t.Fatalf("expected error for malformed hot file content %q", tc.content)
+			}
+		})
+	}
+}
+
+func TestErrComment_NoPathLeakAndNoCommentEscape(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "public"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := newHelperIn(t, dir)
+
+	got, _ := h.Tags("resources/js/app.tsx")
+	s := string(got)
+	// No filesystem path leak.
+	if strings.Contains(s, dir) {
+		t.Errorf("error comment leaked filesystem path: %s", s)
+	}
+	// No comment-escape sequence.
+	if strings.Contains(s, "--&gt;") || strings.Count(s, "-->") != 1 {
+		// Exactly one closing "-->" — the comment terminator we
+		// emit. Any second one would mean injection.
+		t.Errorf("comment integrity broken: %s", s)
+	}
+	if !strings.Contains(s, "manifest not found") {
+		t.Errorf("expected short message, got: %s", s)
+	}
+}
+
+func TestReactRefreshTag_HotMode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "public"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteHotFile(filepath.Join(dir, "public"), "", "http://localhost:5173"); err != nil {
+		t.Fatal(err)
+	}
+	h := newHelperIn(t, dir)
+
+	got, err := h.ReactRefreshTag()
+	if err != nil {
+		t.Fatalf("ReactRefreshTag: %v", err)
+	}
+	s := string(got)
+	for _, want := range []string{
+		`http://localhost:5173/@react-refresh`,
+		`__vite_plugin_react_preamble_installed__`,
+		`RefreshRuntime.injectIntoGlobalHook`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("preamble missing %q\nfull: %s", want, s)
+		}
+	}
+}
+
+func TestReactRefreshTag_ProdModeReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "public"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := newHelperIn(t, dir)
+
+	got, err := h.ReactRefreshTag()
+	if err != nil {
+		t.Fatalf("ReactRefreshTag: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty in prod mode, got: %s", got)
+	}
+}
+
+func TestWriteAndRemoveHotFile(t *testing.T) {
+	dir := t.TempDir()
+	pub := filepath.Join(dir, "public")
+	if err := WriteHotFile(pub, "", "http://localhost:5173"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(pub, "hot"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(b)) != "http://localhost:5173" {
+		t.Errorf("hot file contents = %q", b)
+	}
+	if err := RemoveHotFile(pub, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(pub, "hot")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected hot file to be removed")
+	}
+	// Removing an absent hot file must not error — `vel serve` may
+	// retry shutdown on signal storms.
+	if err := RemoveHotFile(pub, ""); err != nil {
+		t.Errorf("RemoveHotFile on missing file returned %v", err)
+	}
+}
+
+// mustFutureMtime returns a timestamp guaranteed to be after the
+// current mtime of path, so cache invalidation by mtime is observable
+// even on filesystems with coarse (1s) timestamp resolution.
+func mustFutureMtime(t *testing.T, path string) time.Time {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return st.ModTime().Add(2 * time.Second)
+}

--- a/console/serve.go
+++ b/console/serve.go
@@ -72,6 +72,11 @@ func startVite() *exec.Cmd {
 		cli.Warning(fmt.Sprintf("Failed to start Vite: %v", err))
 		return nil
 	}
+
+	// public/hot is managed by the @velocitykode/velocity-vite-plugin
+	// inside Vite's lifecycle — only the plugin knows the resolved
+	// dev origin (HMR overrides, IPv6, custom port). Doing it here
+	// from the spawning process would have to guess.
 	return cmd
 }
 
@@ -85,6 +90,10 @@ func setupGracefulShutdown(viteCmd *exec.Cmd) {
 		<-c
 		cli.Info("Shutting down...")
 		if viteCmd != nil && viteCmd.Process != nil {
+			// SIGTERM the Vite process group; the velocity vite
+			// plugin's own SIGINT/SIGTERM/SIGHUP handlers remove
+			// public/hot before exit so a later `vel build` + run
+			// does not start in dev mode by accident.
 			syscall.Kill(-viteCmd.Process.Pid, syscall.SIGTERM)
 		}
 		os.Exit(0)

--- a/view/view.go
+++ b/view/view.go
@@ -13,6 +13,7 @@ package view
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"net/http"
 	"time"
 
@@ -72,6 +73,15 @@ type Config struct {
 	SSRURL     string        // Defaults to http://127.0.0.1:13714
 	SSRTimeout time.Duration // Defaults to 3s
 	SSRExcept  []string      // URL prefixes to exclude from SSR
+
+	// Funcs registers template helpers callable from RootTemplate. The
+	// canonical use is the bond/vite helper:
+	//
+	//   helper := vite.New()
+	//   cfg.Funcs = template.FuncMap{"vite": helper.Tags}
+	//
+	// Then app.go.html says {{ vite "resources/js/app.tsx" }}.
+	Funcs template.FuncMap
 }
 
 // Engine wraps a bond.Bond instance and provides the view layer API.
@@ -92,6 +102,7 @@ func NewEngine(config Config) (*Engine, error) {
 		RootTemplate: config.RootTemplate,
 		Version:      config.Version,
 		ContainerID:  "app",
+		Funcs:        config.Funcs,
 		SSR: bond.SSRConfig{
 			Enabled: config.SSREnabled,
 			URL:     config.SSRURL,


### PR DESCRIPTION
## Summary

Add a runtime Vite asset helper to bond so root templates can do:

```html
{{ viteReactRefresh }}
{{ vite "resources/js/app.tsx" }}
```

In dev (`public/hot` exists) the helper emits dev-server tags. In prod it reads `public/build/.vite/manifest.json` and emits hashed-URL `<link rel="stylesheet">` + `<script type="module">` tags with `<link rel="modulepreload">` for static imports. Same dev/prod switch shape as `laravel-vite-plugin`'s blade directive, just on the Go side.

## Changes

- **`bond/vite/`** new package (724 lines incl. tests):
  - `Helper.Tags(entrypoints ...string)` — manifest walker, dev-server passthrough.
  - `Helper.ReactRefreshTag()` — emits the `@vitejs/plugin-react` preamble in dev, empty in prod.
  - `Helper.Asset(file)` — single-asset URL.
  - `WriteHotFile` / `RemoveHotFile` for processes that own the dev lifecycle (the companion ` @velocitykode/velocity-vite-plugin` does this from inside Vite, so the framework no longer guesses the dev origin).
  - mtime-validated manifest cache.
- **`bond.Config.Funcs template.FuncMap`** — registered before parsing so templates can call helpers. `parseTemplate(s)` kept 1-arg for back-compat; new `parseTemplateWithFuncs` is the funcs-aware form.
- **`view.Config.Funcs`** — passes through to `bond.Config.Funcs`.
- **`console/serve.go`** — drop the hardcoded ` http://localhost:5173` write of `public/hot`. Hot-file lifecycle is now owned by the vite plugin, which knows the resolved port (HMR overrides, IPv6, custom).

## Defensive

- Hot URL must start with `http(s)://` and contain no whitespace, control bytes, or `<`/`>`/`"` — a corrupt or hand-edited hot file cannot inject content into emitted tags.
- `errComment` strips `-->` and uses short messages (no manifest paths) — comment integrity preserved, no server filesystem path leak.
- 17 new tests; full ` go test ./...` green.

## Test plan

- [x] `go test ./bond/...` — bond + bond/vite suites pass.
- [x] `go test ./view/` — view passes.
- [x] `go test ./console/` — console passes.
- [x] `go test ./...` — full framework suite passes.
- [ ] End-to-end with the [` @velocitykode/velocity-vite-plugin`](https://www.npmjs.com/package/@velocitykode/velocity-vite-plugin) and the matching scaffold change in `velocity-template`. (Followed by a fresh ` velocity new` and an HTTPS deploy.)

## Linked

- npm: https://www.npmjs.com/package/@velocitykode/velocity-vite-plugin
- gh:  https://github.com/velocitykode/velocity-vite-plugin