### PR TITLE
test(bond): deflake SSR response-cap tests under -race

### DIFF
--- a/bond/ssr_test.go
+++ b/bond/ssr_test.go
@@ -476,6 +476,12 @@ func TestHTTPGateway_Dispatch_OversizedResponse_RefusedNotTruncated(t *testing.T
 	defer server.Close()
 
 	gw := NewHTTPGateway(server.URL)
+	// 30s budget so draining the 10 MiB body finishes before the 3s
+	// default SSR deadline under -race on a loaded CI runner. Otherwise
+	// the read races the timeout and surfaces "context deadline exceeded"
+	// instead of the ssrResponseCap refusal this test pins.
+	gw.Timeout = 30 * time.Second
+	gw.Client = &http.Client{Timeout: 30 * time.Second}
 	events := collectSSREvents(gw)
 
 	resp, err := gw.Dispatch(context.Background(), Page{Component: "Home", URL: "/"})
@@ -510,6 +516,10 @@ func TestHTTPGateway_Dispatch_OversizedResponse_ThrowOnError(t *testing.T) {
 	defer server.Close()
 
 	gw := NewHTTPGateway(server.URL)
+	// 30s budget: drain 10 MiB before the 3s default deadline under -race
+	// so the cap refusal fires, not a read timeout (see RefusedNotTruncated).
+	gw.Timeout = 30 * time.Second
+	gw.Client = &http.Client{Timeout: 30 * time.Second}
 	gw.ThrowOnError = true
 
 	resp, err := gw.Dispatch(context.Background(), Page{Component: "Home", URL: "/"})
@@ -549,6 +559,11 @@ func TestHTTPGateway_Dispatch_AtCap_StillSucceeds(t *testing.T) {
 	defer server.Close()
 
 	gw := NewHTTPGateway(server.URL)
+	// 30s budget: a payload of exactly ssrResponseCap must finish reading
+	// before the 3s default deadline under -race, else this boundary test
+	// flakes on "context deadline exceeded" rather than parsing the body.
+	gw.Timeout = 30 * time.Second
+	gw.Client = &http.Client{Timeout: 30 * time.Second}
 	resp, err := gw.Dispatch(context.Background(), Page{Component: "Home", URL: "/"})
 	if err != nil {
 		t.Fatalf("unexpected error at exactly cap: %v", err)


### PR DESCRIPTION
## Problem

CI on `main` (run 27102362086, merge of `piv/test-helpers-p0/transit`) failed:

```
--- FAIL: TestHTTPGateway_Dispatch_OversizedResponse_RefusedNotTruncated (3.31s)
    ssr_test.go:493: expected ErrSSRResponseTooLarge event, got "context deadline exceeded"
```

**Flaky test, not a framework bug.** Three `ssrResponseCap` tests stream ~10 MiB through the gateway and race the 3s default SSR deadline (`defaultSSRTimeout`). Under `-race` on a loaded runner, `io.ReadAll` of the body exceeds 3s → `reqCtx` fires mid-read → gateway surfaces "context deadline exceeded" instead of the cap-refusal / parse path each test pins. Production behaviour is correct (oversized response refused either way → CSR fallback); the tests just over-specify timing.

## Fix

Test-only: give `RefusedNotTruncated`, `ThrowOnError`, and `AtCap_StillSucceeds` a 30s client+context budget so the read always completes before the deadline. Production cap behaviour and the 3s default are unchanged.

## Verification

- Target tests: 10× `-race -count`, all PASS, deterministic (oversized 3.31s→0.05s).
- Full `bond` package: PASS `-race`.
- `go vet ./bond`: clean.